### PR TITLE
Adiciona exemplo de coleta de métricas com Prometheus

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY src ./src
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# ES10-pond-S07-coletando-metricas
+# Coleta de Métricas com Prometheus e Grafana
+
+Este repositório contém um pequeno exemplo para instrumentação de uma aplicação Node.js, coleta de métricas via Prometheus e visualização através do Grafana. O passo a passo a seguir demonstra como reproduzir o ambiente localmente.
+
+## 1. Configuração do Projeto
+
+1. Clone este repositório e navegue até a pasta.
+2. Instale as dependências do projeto:
+   ```bash
+   npm install
+   ```
+3. Inicie o servidor Node.js:
+   ```bash
+   npm start
+   ```
+   A aplicação expõe uma rota `/metrics` com métricas no formato Prometheus e uma rota `/increment` para incrementar um contador de exemplo.
+
+## 2. Preparando Prometheus e Grafana
+
+Utilizaremos **Docker** para subir os serviços. Certifique-se de ter o Docker e o Docker Compose instalados.
+
+1. Construa o container da aplicação Node.js e inicie todos os serviços:
+   ```bash
+   docker-compose up --build
+   ```
+2. Acesse o Prometheus em `http://localhost:9090` e verifique se o alvo `node_app` está sendo coletado.
+3. Acesse o Grafana em `http://localhost:3001` (usuário e senha padrão: `admin`). Configure o Prometheus como fonte de dados apontando para `http://prometheus:9090`.
+4. Crie um dashboard simples e adicione um gráfico exibindo o valor de `example_counter`.
+
+### Visualização
+
+Abaixo está um exemplo simplificado de como o gráfico pode ser exibido no Grafana:
+
+```
++---------------- Grafana Dashboard ---------------+
+|                                                 |
+|  example_counter                                |
+|                                                 |
+|  5 ┤ ████▌                                      |
+|  4 ┤ ███                                        |
+|  3 ┤ ██                                         |
+|  2 ┤ █                                          |
+|  1 ┤▌                                           |
+|                                                 |
++-------------------------------------------------+
+```
+
+## 3. Material de Apoio
+
+- [Alocação de memória](https://www.gta.ufrj.br/~cruz/courses/eel770/slides/9_memoria.pdf)
+- [Fundamentals of garbage collection](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals)
+- [Manipulação de bits](https://www.youtube.com/watch?v=Tuok3H5Girw)
+- Somerville, **Padrões de software**, páginas 458‑460
+
+---
+
+Este repositório serve como base para estudos de instrumentação e visualização de métricas. Personalize conforme necessário para seus experimentos.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  node:
+    build: .
+    ports:
+      - '3000:3000'
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - '9090:9090'
+  grafana:
+    image: grafana/grafana
+    ports:
+      - '3001:3000'
+    depends_on:
+      - prometheus

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "es10-metrics-demo",
+  "version": "1.0.0",
+  "description": "Demo application for Prometheus metrics",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "prom-client": "^15.1.1"
+  }
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: 'node_app'
+    static_configs:
+      - targets: ['node:3000']

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const client = require('prom-client');
+
+const app = express();
+const collectDefaultMetrics = client.collectDefaultMetrics;
+collectDefaultMetrics();
+
+const counter = new client.Counter({
+  name: 'example_counter',
+  help: 'Example counter',
+});
+
+app.get('/increment', (req, res) => {
+  counter.inc();
+  res.send('Counter incremented');
+});
+
+app.get('/metrics', async (req, res) => {
+  res.set('Content-Type', client.register.contentType);
+  res.end(await client.register.metrics());
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- cria exemplo simples em Node.js com `prom-client`
- adiciona `docker-compose.yml` com Prometheus e Grafana
- documenta passo a passo de execução no README

## Testing
- `npm install` *(falha: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684830efbc748326942344191f02b3bf