### PR TITLE
Adiciona coleta avançada e salvamento de gráficos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY src ./src
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# ES10-pond-S07-coletando-metricas
+# Coleta de Métricas com Prometheus e Grafana
+
+Este repositório contém um pequeno exemplo para instrumentação de uma aplicação Node.js, coleta de métricas via Prometheus e visualização através do Grafana. O passo a passo a seguir demonstra como reproduzir o ambiente localmente.
+
+## 1. Configuração do Projeto
+
+1. Clone este repositório e navegue até a pasta.
+2. Instale as dependências do projeto:
+   ```bash
+   npm install
+   ```
+3. Inicie o servidor Node.js:
+   ```bash
+   npm start
+   ```
+    A aplicação expõe diversas rotas:
+    - `/increment` incrementa um contador simples.
+    - `/work` simula uma carga de trabalho e atualiza métricas de duração.
+    - `/metrics` expõe todas as métricas no formato Prometheus.
+    - `/save-graph` gera um gráfico das métricas atuais e o salva na pasta `docs`.
+
+## 2. Preparando Prometheus e Grafana
+
+Utilizaremos **Docker** para subir os serviços. Certifique-se de ter o Docker e o Docker Compose instalados.
+
+1. Construa o container da aplicação Node.js e inicie todos os serviços:
+   ```bash
+   docker-compose up --build
+   ```
+2. Acesse o Prometheus em `http://localhost:9090` e verifique se o alvo `node_app` está sendo coletado.
+3. Acesse o Grafana em `http://localhost:3001` (usuário e senha padrão: `admin`). Configure o Prometheus como fonte de dados apontando para `http://prometheus:9090`.
+4. Crie um dashboard simples e adicione um gráfico exibindo o valor de `example_counter`.
+5. Para registrar uma imagem do gráfico gerado, utilize a rota `/save-graph`. Um arquivo PNG será salvo na pasta `docs`.
+
+### Visualização
+
+Abaixo está um exemplo simplificado de como o gráfico pode ser exibido no Grafana. Após executar a rota `/save-graph`, uma imagem semelhante será gerada em `docs/`:
+
+```
++---------------- Grafana Dashboard ---------------+
+|                                                 |
+|  example_counter                                |
+|                                                 |
+|  5 ┤ ████▌                                      |
+|  4 ┤ ███                                        |
+|  3 ┤ ██                                         |
+|  2 ┤ █                                          |
+|  1 ┤▌                                           |
+|                                                 |
++-------------------------------------------------+
+```
+
+## 3. Material de Apoio
+
+- [Alocação de memória](https://www.gta.ufrj.br/~cruz/courses/eel770/slides/9_memoria.pdf)
+- [Fundamentals of garbage collection](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/fundamentals)
+- [Manipulação de bits](https://www.youtube.com/watch?v=Tuok3H5Girw)
+- Somerville, **Padrões de software**, páginas 458‑460
+
+---
+
+Este repositório serve como base para estudos de instrumentação e visualização de métricas. Personalize conforme necessário para seus experimentos.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  node:
+    build: .
+    ports:
+      - '3000:3000'
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - '9090:9090'
+  grafana:
+    image: grafana/grafana
+    ports:
+      - '3001:3000'
+    depends_on:
+      - prometheus

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+Esta pasta armazenará imagens PNG geradas pela rota /save-graph.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "es10-metrics-demo",
+  "version": "1.0.0",
+  "description": "Demo application for Prometheus metrics",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+    "dependencies": {
+      "express": "^4.18.2",
+      "prom-client": "^15.1.1",
+      "chartjs-node-canvas": "^4.1.7"
+    }
+  }

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,4 @@
+scrape_configs:
+  - job_name: 'node_app'
+    static_configs:
+      - targets: ['node:3000']

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,102 @@
+// Exemplo de servidor Express instrumentado com Prometheus
+// Todos os comentários estão em português para facilitar o entendimento
+const express = require('express');
+const client = require('prom-client');
+const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+// Coleta das métricas padrão do Node.js (uso de CPU, memória etc.)
+const collectDefaultMetrics = client.collectDefaultMetrics;
+collectDefaultMetrics();
+
+// Contador simples para demonstrar incremento manual
+const counter = new client.Counter({
+  name: 'example_counter',
+  help: 'Exemplo de contador',
+});
+
+// Gauge para monitorar o tempo (em ms) de uma operação simulada
+const workTimeGauge = new client.Gauge({
+  name: 'work_time_ms',
+  help: 'Tempo da última operação em milissegundos',
+});
+
+// Histograma para medir a duração das requisições HTTP
+const requestDuration = new client.Histogram({
+  name: 'http_request_duration_ms',
+  help: 'Duração das requisições HTTP em ms',
+  buckets: [50, 100, 200, 500, 1000],
+});
+
+// Configurações do Chart.js para geração de imagens
+const width = 800;
+const height = 600;
+const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
+
+// Rota para simular uma carga de trabalho e coletar métricas mais complexas
+app.get('/work', async (req, res) => {
+  // Início da medição do tempo de requisição
+  const end = requestDuration.startTimer();
+  const workTime = Math.random() * 400; // tempo aleatório de até 400ms
+
+  // Ajusta o gauge com o tempo calculado
+  workTimeGauge.set(workTime);
+
+  // Simula tarefa assíncrona
+  await new Promise(r => setTimeout(r, workTime));
+
+  // Finaliza a medição de duração
+  end();
+
+  res.send('Trabalho concluído');
+});
+
+// Endpoint para gerar e salvar um gráfico na pasta docs
+app.get('/save-graph', async (req, res) => {
+  // Coleta os valores atuais do histograma
+  const metrics = await client.register.getSingleMetricAsString('http_request_duration_ms_bucket');
+
+  const labels = [];
+  const values = [];
+
+  metrics.split('\n').forEach(line => {
+    const match = line.match(/http_request_duration_ms_bucket{le="?(\d+)"?} (\d+)/);
+    if (match) {
+      labels.push(match[1]);
+      values.push(parseInt(match[2], 10));
+    }
+  });
+
+  const configuration = {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{ label: 'Quantidade', data: values }],
+    },
+  };
+
+  const image = await chartJSNodeCanvas.renderToBuffer(configuration);
+  const docsDir = path.join(__dirname, '..', 'docs');
+  if (!fs.existsSync(docsDir)) fs.mkdirSync(docsDir, { recursive: true });
+  const filePath = path.join(docsDir, `grafico_${Date.now()}.png`);
+  fs.writeFileSync(filePath, image);
+
+  res.send(`Gráfico salvo em ${filePath}`);
+});
+
+app.get('/increment', (req, res) => {
+  counter.inc();
+  res.send('Counter incremented');
+});
+
+app.get('/metrics', async (req, res) => {
+  res.set('Content-Type', client.register.contentType);
+  res.end(await client.register.metrics());
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- adiciona métricas de histograma e gauge no servidor
- permite gerar imagens de gráficos em `docs/`
- descreve novas rotas e passos no README
- inclui dependência `chartjs-node-canvas`

## Testing
- `npm install` *(falha: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684830efbc748326942344191f02b3bf